### PR TITLE
Added strict to helm lint

### DIFF
--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -50,7 +50,7 @@ func (h Helm) LintWithValues(chart string, valuesFile string) error {
 		values = []string{"--values", valuesFile}
 	}
 
-	return h.exec.RunProcess("helm", "lint", chart, values)
+	return h.exec.RunProcess("helm", "lint", "--strict", chart, values)
 }
 
 func (h Helm) InstallWithValues(chart string, valuesFile string, namespace string, release string) error {


### PR DESCRIPTION
The biggest reason that `--strict` is needed is for the reason of missing key/pair values.  If something is missing from the values file then the `lint` needs to fail.